### PR TITLE
DRAFT: Changes for session and schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.ing.data</groupId>
 	<artifactId>cassandra-jdbc-wrapper</artifactId>
-    <version>4.5.1</version>
+    <version>4.5.2-ds</version>
 	<packaging>jar</packaging>
 
 	<name>Cassandra JDBC Wrapper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.ing.data</groupId>
 	<artifactId>cassandra-jdbc-wrapper</artifactId>
-    <version>4.5.0</version>
+    <version>4.5.1</version>
 	<packaging>jar</packaging>
 
 	<name>Cassandra JDBC Wrapper</name>
@@ -69,9 +69,9 @@
         <java.version>1.8</java.version>
 
         <!-- Versions for dependencies -->
-        <cassandra-all.version>3.11.9</cassandra-all.version>
+        <cassandra-all.version>3.11.12</cassandra-all.version>
         <commons-lang3.version>3.11</commons-lang3.version>
-        <datastax.java.driver.version>4.10.0</datastax.java.driver.version>
+        <datastax.java.driver.version>4.13.0</datastax.java.driver.version>
         <libthrift.version>0.13.0</libthrift.version>
         <!-- Versions for test dependencies -->
         <achilles-embedded.version>6.0.4</achilles-embedded.version>
@@ -96,26 +96,13 @@
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
             <version>${datastax.java.driver.version}</version>
+			<scope>provided</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.cassandra</groupId>
-            <artifactId>cassandra-all</artifactId>
-            <version>${cassandra-all.version}</version>
-            <!-- Exclude vulnerable dependencies -->
-            <exclusions>
-                <!-- The version of libthrift is overridden below. -->
-                <exclusion>
-                    <groupId>org.apache.thrift</groupId>
-                    <artifactId>libthrift</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- Force the use of a more recent version of libthrift. -->
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <version>${libthrift.version}</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
         </dependency>
 
         <!-- Apache Commons Lang 3 -->

--- a/src/main/java/com/ing/data/cassandra/jdbc/ByteBufferUtil.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/ByteBufferUtil.java
@@ -1,0 +1,71 @@
+package com.ing.data.cassandra.jdbc;
+
+import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.UUID;
+
+public class ByteBufferUtil {
+    public static ByteBuffer bytes(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    public static ByteBuffer bytes(byte b) {
+        return ByteBuffer.allocate(1).put(0, b);
+    }
+
+    public static ByteBuffer bytes(short s) {
+        return ByteBuffer.allocate(2).putShort(0, s);
+    }
+
+    public static ByteBuffer bytes(int i) {
+        return ByteBuffer.allocate(4).putInt(0, i);
+    }
+
+    public static ByteBuffer bytes(long n) {
+        return ByteBuffer.allocate(8).putLong(0, n);
+    }
+
+    public static ByteBuffer bytes(float f) {
+        return ByteBuffer.allocate(4).putFloat(0, f);
+    }
+
+    public static ByteBuffer bytes(double d) {
+        return ByteBuffer.allocate(8).putDouble(0, d);
+    }
+
+    public static int toInt(ByteBuffer bytes) {
+        return bytes.getInt(bytes.position());
+    }
+
+    public static short toShort(ByteBuffer bytes) {
+        return bytes.getShort(bytes.position());
+    }
+
+    public static long toLong(ByteBuffer bytes) {
+        return bytes.getLong(bytes.position());
+    }
+
+    public static float toFloat(ByteBuffer bytes) {
+        return bytes.getFloat(bytes.position());
+    }
+
+    public static double toDouble(ByteBuffer bytes) {
+        return bytes.getDouble(bytes.position());
+    }
+
+    public static byte[] getArray(ByteBuffer buffer) {
+        int length = buffer.remaining();
+        if (buffer.hasArray()) {
+            int boff = buffer.arrayOffset() + buffer.position();
+            return Arrays.copyOfRange(buffer.array(), boff, boff + length);
+        } else {
+            byte[] bytes = new byte[length];
+            buffer.duplicate().get(bytes);
+            return bytes;
+        }
+    }
+
+}

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraStatement.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraStatement.java
@@ -415,8 +415,8 @@ public class CassandraStatement extends AbstractStatement
     public int executeUpdate(final String cql) throws SQLException {
         checkNotClosed();
         doExecute(cql);
-        // There is no updateCount available in Datastax Java driver, so return 0.
-        return 0;
+        // There is no updateCount available in Datastax Java driver, so return -1.
+        return -1;
     }
 
     @Override

--- a/src/main/java/com/ing/data/cassandra/jdbc/DataTypeEnum.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/DataTypeEnum.java
@@ -21,7 +21,6 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.protocol.internal.ProtocolConstants.DataType;
 import com.google.common.collect.Maps;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.db.marshal.CollectionType;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -53,9 +52,9 @@ public enum DataTypeEnum {
     FLOAT(DataType.FLOAT, Float.class, cqlName(DataTypes.FLOAT)),
     INET(DataType.INET, InetAddress.class, cqlName(DataTypes.INET)),
     INT(DataType.INT, Integer.class, cqlName(DataTypes.INT)),
-    LIST(DataType.LIST, List.class, CollectionType.Kind.LIST.name().toLowerCase()),
-    MAP(DataType.MAP, Map.class, CollectionType.Kind.MAP.name().toLowerCase()),
-    SET(DataType.SET, Set.class, CollectionType.Kind.SET.name().toLowerCase()),
+    LIST(DataType.LIST, List.class, "list"),
+    MAP(DataType.MAP, Map.class, "map"),
+    SET(DataType.SET, Set.class, "set"),
     SMALLINT(DataType.SMALLINT, Short.class, cqlName(DataTypes.SMALLINT)),
     TEXT(DataType.VARCHAR, String.class, cqlName(DataTypes.TEXT)),
     TIME(DataType.TIME, Time.class, cqlName(DataTypes.TIME)),

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/BigintToBigDecimalCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/BigintToBigDecimalCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/DecimalToDoubleCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/DecimalToDoubleCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/FloatToDoubleCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/FloatToDoubleCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/IntToLongCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/IntToLongCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/LongToIntCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/LongToIntCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/SmallintToIntCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/SmallintToIntCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/TimestampToLongCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/TimestampToLongCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/TinyintToIntCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/TinyintToIntCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/main/java/com/ing/data/cassandra/jdbc/codec/VarintToIntCodec.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/codec/VarintToIntCodec.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 
 import java.nio.ByteBuffer;
 

--- a/src/test/java/com/ing/data/cassandra/jdbc/codec/BigintToBigDecimalCodecTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/codec/BigintToBigDecimalCodecTest.java
@@ -16,7 +16,7 @@ package com.ing.data.cassandra.jdbc.codec;
 import com.datastax.oss.driver.api.core.ProtocolVersion;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.core.type.reflect.GenericType;
-import org.apache.cassandra.utils.ByteBufferUtil;
+import com.ing.data.cassandra.jdbc.ByteBufferUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
This need a discussion first.
Background liquibase cassandra uses  outdated Simba JDBC driver; This project would be perfect fit for replacing it.

First thing, there is different concepts about catalog, You use cluster as catalog, as liquibase (simba) expects keyspace. And thus ailing on some checks:
getColumns <..>
        if (catalog != null && !catalog.equals(this.connection.getCatalog())) 

The solution could be either make this configurable, or suggest another solution.

Update also need review. 

And passing a session would benefit 

(Will edit message to explain in detail) 


