### PR TITLE
Fix CassandraMetadataResultSet to return JDBC-specified defaults

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/MetadataRow.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/MetadataRow.java
@@ -180,6 +180,9 @@ public class MetadataRow {
      * @throws NumberFormatException if the value is not a parsable {@code int} value.
      */
     public int getInt(final int i) {
+        if (isNull(i)) {
+            return 0;
+        }
         return Integer.parseInt(this.entries.get(i));
     }
 

--- a/src/test/java/com/ing/data/cassandra/jdbc/JdbcRegressionUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/JdbcRegressionUnitTest.java
@@ -871,4 +871,30 @@ class JdbcRegressionUnitTest extends UsingEmbeddedCassandraServerTest {
         statementSelect.close();
     }
 
+    @Test
+    void testIngIssue10() throws Exception {
+        final DatabaseMetaData md = sqlConnection.getMetaData();
+
+        final String COLUMN = "keyname";
+
+        ResultSet result;
+
+        result = md.getColumns(sqlConnection.getCatalog(), KEYSPACE, TABLE, null);
+        assertTrue(result.next());
+        assertEquals(TABLE, result.getString("TABLE_NAME"));
+        // Check column names and types.
+        assertEquals(COLUMN, result.getString("COLUMN_NAME"));
+        assertEquals(false, result.wasNull());
+
+        // The underlying value of the DECIMAL_DIGITS field is null, so
+        // getInt should return 0, but wasNull should be true
+        assertEquals(0, result.getInt("DECIMAL_DIGITS"));
+        assertEquals(true, result.wasNull());
+
+        // Get another field to ensure wasNull is reset to false
+        assertEquals(Types.VARCHAR, result.getInt("DATA_TYPE"));
+        assertEquals(false, result.wasNull());
+
+        result.close();
+    }
 }


### PR DESCRIPTION
Fix CassandraMetadataResultSet to return JDBC-specified defaults if underlying data is NULL - fixes https://github.com/ing-bank/cassandra-jdbc-wrapper/issues/10