### PR TITLE
Fix issue #25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,16 +99,16 @@ local.properties
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
+# since they will be recreated, and may cause churn. Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
 
 # CMake
 cmake-build-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.1] - 2023-09-03
+### Fixed
+- Fix issue [#25](https://github.com/ing-bank/cassandra-jdbc-wrapper/issues/25) causing failure when running with
+  Liquibase. The fix includes several changes:
+  - fixes result sets and statements closing. 
+  - introduces a new behaviour in Liquibase compliance mode to run multiple queries in the same statement synchronously 
+    (by default, they are executed asynchronously). 
+  - returns the schema name instead of `null` when the method `CassandraConnection.getCatalog()` is called in Liquibase 
+    compliance mode.
+  - does not throw `SQLFeatureNotSupportedException` when `CassandraConnection.rollback()` is called in Liquibase 
+    compliance mode.
+
 ## [4.9.0] - 2023-04-15
 ### Added
 - Add non-JDBC standard [JSON support](https://cassandra.apache.org/doc/latest/cassandra/cql/json.html) with the 
@@ -121,6 +133,7 @@ For this version, the changelog lists the main changes comparatively to the late
 - Fix logs in `CassandraConnection` constructor.
 
 [original project]: https://github.com/adejanovski/cassandra-jdbc-wrapper/
+[4.9.1]: https://github.com/ing-bank/cassandra-jdbc-wrapper/compare/v4.9.0...v4.9.1
 [4.9.0]: https://github.com/ing-bank/cassandra-jdbc-wrapper/compare/v4.8.0...v4.9.0
 [4.8.0]: https://github.com/ing-bank/cassandra-jdbc-wrapper/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/ing-bank/cassandra-jdbc-wrapper/compare/v4.6.0...v4.7.0

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ For further information about connecting to DBaaS, see [cloud documentation](htt
 ### Compliance modes
 
 For some specific usages, the default behaviour of some JDBC implementations has to be modified. That's why you can
-use the argument `compliancemode` in the JDBC URL to cutomize the behaviour of some methods.
+use the argument `compliancemode` in the JDBC URL to customize the behaviour of some methods.
 
 The values currently allowed for this argument are:
 * `Default`: mode activated by default if not specified in the JDBC URL. It implements the methods detailed below as 
@@ -293,10 +293,19 @@ The values currently allowed for this argument are:
 
 Here are the behaviours defined by the compliance modes listed above:
 
-| Method                                     | Default mode                                                                                      | Liquibase mode |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------|----------------|
-| `CassandraConnection.getCatalog()`         | returns the result of the query`SELECT cluster_name FROM system.local` or `null` if not available | returns `null` |
-| `CassandraStatement.executeUpdate(String)` | returns 0                                                                                         | returns -1     |
+| Method                                     | Default mode                                                                                      | Liquibase mode                                         |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| `CassandraConnection.getCatalog()`         | returns the result of the query`SELECT cluster_name FROM system.local` or `null` if not available | returns the schema name if available, `null` otherwise |
+| `CassandraConnection.rollback()`           | throws a `SQLFeatureNotSupportedException`                                                        | do nothing more after checking connection is open      |
+| `CassandraStatement.executeUpdate(String)` | returns 0                                                                                         | returns -1                                             |
+
+For the following methods: `CassandraStatement.execute(String)`, `CassandraStatement.executeQuery(String)` and
+`CassandraStatement.executeUpdate(String)`, if the CQL statement includes several queries (separated by semicolons),
+the behaviour is the following:
+
+| Default mode                        | Liquibase mode                     |
+|-------------------------------------|------------------------------------|
+| executes the queries asynchronously | executes the queries synchronously |
 
 ### Using simple statements
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.ing.data</groupId>
 	<artifactId>cassandra-jdbc-wrapper</artifactId>
-    <version>4.9.0</version>
+    <version>4.9.1</version>
 	<packaging>jar</packaging>
 
 	<name>Cassandra JDBC Wrapper</name>

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraConnection.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraConnection.java
@@ -547,7 +547,9 @@ public class CassandraConnection extends AbstractConnection implements Connectio
     @Override
     public void rollback() throws SQLException {
         checkNotClosed();
-        throw new SQLFeatureNotSupportedException(ALWAYS_AUTOCOMMIT);
+        if (this.optionSet.shouldThrowExceptionOnRollback()) {
+            throw new SQLFeatureNotSupportedException(ALWAYS_AUTOCOMMIT);
+        }
     }
 
     /**

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraMetadataResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraMetadataResultSet.java
@@ -128,6 +128,7 @@ public class CassandraMetadataResultSet extends AbstractResultSet implements Cas
     private int fetchDirection;
     private int fetchSize;
     private boolean wasNull;
+    private boolean isClosed;
     // Result set from the Cassandra driver.
     private MetadataResultSet driverResultSet;
 
@@ -137,6 +138,7 @@ public class CassandraMetadataResultSet extends AbstractResultSet implements Cas
     CassandraMetadataResultSet() {
         this.metadata = new CResultSetMetaData();
         this.statement = null;
+        this.isClosed = false;
     }
 
     /**
@@ -156,6 +158,7 @@ public class CassandraMetadataResultSet extends AbstractResultSet implements Cas
         this.fetchSize = statement.getFetchSize();
         this.driverResultSet = metadataResultSet;
         this.rowsIterator = metadataResultSet.iterator();
+        this.isClosed = false;
 
         // Initialize the column values from the first row.
         // Note that the first call to next() will harmlessly re-write these values for the columns. The row cursor
@@ -250,7 +253,7 @@ public class CassandraMetadataResultSet extends AbstractResultSet implements Cas
     @Override
     public void close() throws SQLException {
         if (!isClosed()) {
-            this.statement.close();
+            this.isClosed = true;
         }
     }
 
@@ -961,10 +964,7 @@ public class CassandraMetadataResultSet extends AbstractResultSet implements Cas
 
     @Override
     public boolean isClosed() {
-        if (this.statement == null) {
-            return true;
-        }
-        return this.statement.isClosed();
+        return this.isClosed;
     }
 
     @Override

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
@@ -176,6 +176,7 @@ public class CassandraResultSet extends AbstractResultSet
     private int fetchDirection;
     private int fetchSize;
     private boolean wasNull;
+    private boolean isClosed;
     // Result set from the Cassandra driver.
     private ResultSet driverResultSet;
 
@@ -185,6 +186,7 @@ public class CassandraResultSet extends AbstractResultSet
     CassandraResultSet() {
         this.metadata = new CResultSetMetaData();
         this.statement = null;
+        this.isClosed = false;
     }
 
     /**
@@ -203,6 +205,7 @@ public class CassandraResultSet extends AbstractResultSet
         this.fetchSize = statement.getFetchSize();
         this.driverResultSet = resultSet;
         this.rowsIterator = resultSet.iterator();
+        this.isClosed = false;
 
         // Initialize the column values from the first row.
         if (hasMoreRows()) {
@@ -225,6 +228,7 @@ public class CassandraResultSet extends AbstractResultSet
         this.resultSetType = statement.getResultSetType();
         this.fetchDirection = statement.getFetchDirection();
         this.fetchSize = statement.getFetchSize();
+        this.isClosed = false;
 
         // We have several result sets, but we will use only the first one for metadata needs.
         this.driverResultSet = resultSets.get(0);
@@ -324,7 +328,7 @@ public class CassandraResultSet extends AbstractResultSet
     @Override
     public void close() throws SQLException {
         if (!isClosed()) {
-            this.statement.close();
+            this.isClosed = true;
         }
     }
 
@@ -1366,10 +1370,7 @@ public class CassandraResultSet extends AbstractResultSet
 
     @Override
     public boolean isClosed() {
-        if (this.statement == null) {
-            return true;
-        }
-        return this.statement.isClosed();
+        return this.isClosed;
     }
 
     @Override

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraStatement.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraStatement.java
@@ -137,7 +137,7 @@ public class CassandraStatement extends AbstractStatement
      * The consistency level used for the statement.
      */
     protected ConsistencyLevel consistencyLevel;
-
+    private boolean isClosed;
     private DriverExecutionProfile customTimeoutProfile;
 
     /**
@@ -210,6 +210,7 @@ public class CassandraStatement extends AbstractStatement
         this.cql = cql;
         this.batchQueries = new ArrayList<>();
         this.consistencyLevel = connection.getDefaultConsistencyLevel();
+        this.isClosed = false;
 
         if (!(resultSetType == ResultSet.TYPE_FORWARD_ONLY
             || resultSetType == ResultSet.TYPE_SCROLL_INSENSITIVE
@@ -264,7 +265,7 @@ public class CassandraStatement extends AbstractStatement
 
     @Override
     public void close() {
-        this.connection = null;
+        this.isClosed = true;
         this.cql = null;
     }
 
@@ -284,67 +285,68 @@ public class CassandraStatement extends AbstractStatement
 
         try {
             final String[] cqlQueries = cql.split(STATEMENTS_SEPARATOR_REGEX);
-            if (cqlQueries.length > 1 && !(cql.trim().toLowerCase().startsWith("begin")
+            if (cqlQueries.length > 1
+                && !(cql.trim().toLowerCase().startsWith("begin")
                 && cql.toLowerCase().contains("batch") && cql.toLowerCase().contains("apply"))) {
-                // Several statements in the query to execute asynchronously...
-
                 final ArrayList<com.datastax.oss.driver.api.core.cql.ResultSet> results = new ArrayList<>();
+
+                // Several statements in the query to execute asynchronously...
                 if (cqlQueries.length > MAX_ASYNC_QUERIES * 1.1) {
                     // Protect the cluster from receiving too many queries at once and force the dev to split the load
                     throw new SQLNonTransientException("Too many queries at once (" + cqlQueries.length
                         + "). You must split your queries into more batches !");
                 }
 
-                StringBuilder prevCqlQuery = new StringBuilder();
-                for (final String cqlQuery : cqlQueries) {
-                    if ((cqlQuery.contains("'") && ((StringUtils.countMatches(cqlQuery, "'") % 2 == 1
-                        && prevCqlQuery.length() == 0)
-                        || (StringUtils.countMatches(cqlQuery, "'") % 2 == 0 && prevCqlQuery.length() > 0)))
-                        || (prevCqlQuery.toString().length() > 0 && !cqlQuery.contains("'"))) {
-                        prevCqlQuery.append(cqlQuery).append(";");
-                    } else {
-                        prevCqlQuery.append(cqlQuery);
-                        if (LOG.isTraceEnabled() || this.connection.isDebugMode()) {
-                            LOG.debug("CQL: {}", prevCqlQuery);
-                        }
-                        SimpleStatement stmt = SimpleStatement.newInstance(prevCqlQuery.toString())
-                            .setConsistencyLevel(this.connection.getDefaultConsistencyLevel())
-                            .setPageSize(this.fetchSize);
-                        if (this.customTimeoutProfile != null) {
-                            stmt = stmt.setExecutionProfile(this.customTimeoutProfile);
-                        }
-                        final CompletionStage<AsyncResultSet> resultSetFuture =
-                            ((CqlSession) this.connection.getSession()).executeAsync(stmt);
-                        futures.add(resultSetFuture);
-                        prevCqlQuery = new StringBuilder();
+                // If we should not execute the queries asynchronously, for example if they must be executed in the
+                // specified order (e.g. in Liquibase scripts with queries such as CREATE TABLE t, then
+                // INSERT INTO t ...).
+                if (!this.connection.getOptionSet().executeMultipleQueriesByStatementAsync()) {
+                    for (final String cqlQuery : cqlQueries) {
+                        final com.datastax.oss.driver.api.core.cql.ResultSet rs = executeSingleStatement(cqlQuery);
+                        results.add(rs);
                     }
-                }
+                } else {
+                    StringBuilder prevCqlQuery = new StringBuilder();
+                    for (final String cqlQuery : cqlQueries) {
+                        if ((cqlQuery.contains("'") && ((StringUtils.countMatches(cqlQuery, "'") % 2 == 1
+                            && prevCqlQuery.length() == 0)
+                            || (StringUtils.countMatches(cqlQuery, "'") % 2 == 0 && prevCqlQuery.length() > 0)))
+                            || (!prevCqlQuery.toString().isEmpty() && !cqlQuery.contains("'"))) {
+                            prevCqlQuery.append(cqlQuery).append(";");
+                        } else {
+                            prevCqlQuery.append(cqlQuery);
+                            if (LOG.isTraceEnabled() || this.connection.isDebugMode()) {
+                                LOG.debug("CQL: {}", prevCqlQuery);
+                            }
+                            SimpleStatement stmt = SimpleStatement.newInstance(prevCqlQuery.toString())
+                                .setConsistencyLevel(this.connection.getDefaultConsistencyLevel())
+                                .setPageSize(this.fetchSize);
+                            if (this.customTimeoutProfile != null) {
+                                stmt = stmt.setExecutionProfile(this.customTimeoutProfile);
+                            }
+                            final CompletionStage<AsyncResultSet> resultSetFuture =
+                                ((CqlSession) this.connection.getSession()).executeAsync(stmt);
+                            futures.add(resultSetFuture);
+                            prevCqlQuery = new StringBuilder();
+                        }
+                    }
 
-                for (final CompletionStage<AsyncResultSet> future : futures) {
-                    final AsyncResultSet asyncResultSet = CompletableFutures.getUninterruptibly(future);
-                    final com.datastax.oss.driver.api.core.cql.ResultSet rows;
-                    if (asyncResultSet.hasMorePages()) {
-                        rows = new MultiPageResultSet(asyncResultSet);
-                    } else {
-                        rows = new SinglePageResultSet(asyncResultSet);
+                    for (final CompletionStage<AsyncResultSet> future : futures) {
+                        final AsyncResultSet asyncResultSet = CompletableFutures.getUninterruptibly(future);
+                        final com.datastax.oss.driver.api.core.cql.ResultSet rows;
+                        if (asyncResultSet.hasMorePages()) {
+                            rows = new MultiPageResultSet(asyncResultSet);
+                        } else {
+                            rows = new SinglePageResultSet(asyncResultSet);
+                        }
+                        results.add(rows);
                     }
-                    results.add(rows);
                 }
 
                 this.currentResultSet = new CassandraResultSet(this, results);
             } else {
                 // Only one statement to execute, so do it synchronously.
-                if (LOG.isTraceEnabled() || this.connection.isDebugMode()) {
-                    LOG.debug("CQL: " + cql);
-                }
-                SimpleStatement stmt = SimpleStatement.newInstance(cql)
-                    .setConsistencyLevel(this.connection.getDefaultConsistencyLevel())
-                    .setPageSize(this.fetchSize);
-                if (this.customTimeoutProfile != null) {
-                    stmt = stmt.setExecutionProfile(this.customTimeoutProfile);
-                }
-                this.currentResultSet = new CassandraResultSet(this,
-                    ((CqlSession) this.connection.getSession()).execute(stmt));
+                this.currentResultSet = new CassandraResultSet(this, executeSingleStatement(cql));
             }
         } catch (final Exception e) {
             for (final CompletionStage<AsyncResultSet> future : futures) {
@@ -352,6 +354,19 @@ public class CassandraStatement extends AbstractStatement
             }
             throw new SQLTransientException(e);
         }
+    }
+
+    private com.datastax.oss.driver.api.core.cql.ResultSet executeSingleStatement(final String cql) {
+        if (LOG.isTraceEnabled() || this.connection.isDebugMode()) {
+            LOG.debug("CQL: " + cql);
+        }
+        SimpleStatement stmt = SimpleStatement.newInstance(cql)
+            .setConsistencyLevel(this.connection.getDefaultConsistencyLevel())
+            .setPageSize(this.fetchSize);
+        if (this.customTimeoutProfile != null) {
+            stmt = stmt.setExecutionProfile(this.customTimeoutProfile);
+        }
+        return ((CqlSession) this.connection.getSession()).execute(stmt);
     }
 
     @Override
@@ -647,7 +662,7 @@ public class CassandraStatement extends AbstractStatement
 
     @Override
     public boolean isClosed() {
-        return this.connection == null;
+        return this.isClosed;
     }
 
     /**

--- a/src/main/java/com/ing/data/cassandra/jdbc/optionset/Default.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/optionset/Default.java
@@ -50,4 +50,13 @@ public class Default extends AbstractOptionSet {
         return 0;
     }
 
+    @Override
+    public boolean shouldThrowExceptionOnRollback() {
+        return true;
+    }
+
+    @Override
+    public boolean executeMultipleQueriesByStatementAsync() {
+        return true;
+    }
 }

--- a/src/main/java/com/ing/data/cassandra/jdbc/optionset/Liquibase.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/optionset/Liquibase.java
@@ -15,14 +15,28 @@
 
 package com.ing.data.cassandra.jdbc.optionset;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+
 /**
  * Option set implementation for Liquibase compatibility and flavour of JDBC.
  */
 public class Liquibase extends AbstractOptionSet {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractOptionSet.class);
 
     @Override
     public String getCatalog() {
-        return null;
+        if (getConnection() == null) {
+            return null;
+        }
+        try {
+            return getConnection().getSchema();
+        } catch (final SQLException e) {
+            LOG.warn("Unable to retrieve the schema name: {}", e.getMessage());
+            return null;
+        }
     }
 
     @Override
@@ -30,4 +44,13 @@ public class Liquibase extends AbstractOptionSet {
         return -1;
     }
 
+    @Override
+    public boolean shouldThrowExceptionOnRollback() {
+        return false;
+    }
+
+    @Override
+    public boolean executeMultipleQueriesByStatementAsync() {
+        return false;
+    }
 }

--- a/src/main/java/com/ing/data/cassandra/jdbc/optionset/OptionSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/optionset/OptionSet.java
@@ -17,6 +17,8 @@ package com.ing.data.cassandra.jdbc.optionset;
 
 import com.ing.data.cassandra.jdbc.CassandraConnection;
 
+import java.sql.SQLFeatureNotSupportedException;
+
 /**
  * Option set for compliance mode.
  * Different use cases require one or more adjustments to the wrapper, to be compatible.
@@ -37,6 +39,23 @@ public interface OptionSet {
      * @return A predefined update response.
      */
     int getSQLUpdateResponse();
+
+    /**
+     * Whether the rollback method on a Cassandra connection should throw a {@link SQLFeatureNotSupportedException}
+     * since Cassandra is always in auto-commit mode and does not support rollback.
+     *
+     * @return {@code true} if the method {@link CassandraConnection#rollback()} should throw an exception,
+     * {@code false} otherwise.
+     */
+    boolean shouldThrowExceptionOnRollback();
+
+    /**
+     * Whether the statement execution methods must execute queries asynchronously when the statement contains several
+     * queries separated by semicolons.
+     *
+     * @return {@code true} if the queries must be executed asynchronously, {@code false} otherwise.
+     */
+    boolean executeMultipleQueriesByStatementAsync();
 
     /**
      * Set referenced connection. See @{@link AbstractOptionSet}.

--- a/src/test/java/com/ing/data/cassandra/jdbc/ConnectionUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/ConnectionUnitTest.java
@@ -407,12 +407,14 @@ class ConnectionUnitTest extends UsingCassandraContainerTest {
                 .withLocalDatacenter("datacenter1")
                 .build();
 
+        final Liquibase liquibaseMode = new Liquibase();
         final CassandraConnection jdbcConnection =
-            new CassandraConnection(session, KEYSPACE, ConsistencyLevel.ALL, false, new Liquibase());
+            new CassandraConnection(session, KEYSPACE, ConsistencyLevel.ALL, false, liquibaseMode);
+        liquibaseMode.setConnection(jdbcConnection);
         final ResultSet resultSet = jdbcConnection.createStatement()
             .executeQuery("SELECT release_version FROM system.local");
         assertNotNull(resultSet.getString("release_version"));
-        assertNull(jdbcConnection.getCatalog());
+        assertEquals(KEYSPACE, jdbcConnection.getCatalog());
     }
 
     @Test


### PR DESCRIPTION
- fix result sets and statements closing.
- introduce a new behaviour in Liquibase compliance mode to run multiple queries in the same statement synchronously (by default, they are executed asynchronously).
- return the schema name instead of null when the method CassandraConnection.getCatalog() is called in Liquibase compliance mode.
- does not throw SQLFeatureNotSupportedException when CassandraConnection.rollback() is called in Liquibase compliance mode.