### PR TITLE
JDBC ResultSet should count columns from 1 and not 0

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
@@ -332,7 +332,7 @@ public class CassandraResultSet extends AbstractResultSet
     public int findColumn(final String columnLabel) throws SQLException {
         checkNotClosed();
         checkName(columnLabel);
-        return this.currentRow.getColumnDefinitions().firstIndexOf(columnLabel);
+        return this.currentRow.getColumnDefinitions().firstIndexOf(columnLabel)+1;
     }
 
     @Override
@@ -1003,7 +1003,7 @@ public class CassandraResultSet extends AbstractResultSet
     @Override
     public <T> T getObject(final String columnLabel, final Class<T> type) throws SQLException {
         final int index = findColumn(columnLabel);
-        return getObject(index + 1, type);
+        return getObject(index, type);
     }
 
     @Override
@@ -1125,7 +1125,7 @@ public class CassandraResultSet extends AbstractResultSet
     @Override
     public <T> T getObjectFromJson(final String columnLabel, final Class<T> type) throws SQLException {
         final int index = findColumn(columnLabel);
-        return getObjectFromJson(index + 1, type);
+        return getObjectFromJson(index, type);
     }
 
     @Override


### PR DESCRIPTION
This PR should fix #31 on tag 4.9.0
I could not apply it on 4.10 because I had issues like java.lang.ClassNotFoundException: com.datastax.oss.driver.api.core.data.CqlVector when running the wrapper. 
I could not run the test suite because of the dependencies on a docker environment, but the PR is small enough to be included once you see the test suite pass in your environment.

