### PR TITLE
Always leverage latest docker 5 image

### DIFF
--- a/src/test/java/com/ing/data/cassandra/jdbc/UsingCassandraContainerTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/UsingCassandraContainerTest.java
@@ -28,7 +28,7 @@ import java.sql.DriverManager;
 abstract class UsingCassandraContainerTest {
 
     // For the official Cassandra image, see here: https://hub.docker.com/_/cassandra
-    static final DockerImageName CASSANDRA_IMAGE = DockerImageName.parse("cassandra:5.0");
+    static final DockerImageName CASSANDRA_IMAGE = DockerImageName.parse("cassandra:5");
 
     static CassandraConnection sqlConnection = null;
 


### PR DESCRIPTION
I've worked with the Docker community to get a `5` tag which will always point to the latest `5.x` series. This will be a helpful one-time change here.