### PR TITLE
Statement.execute should return true even if result set has no rows

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraPreparedStatement.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraPreparedStatement.java
@@ -248,7 +248,7 @@ public class CassandraPreparedStatement extends CassandraStatement
         doExecute();
         // Return true if the first result is a non-null ResultSet object; false if the first result is an update count
         // or there is no result.
-        return this.currentResultSet != null && ((CassandraResultSet) this.currentResultSet).hasMoreRows();
+        return this.currentResultSet != null && ((CassandraResultSet) this.currentResultSet).isQuery();
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
@@ -1535,6 +1535,10 @@ public class CassandraResultSet extends AbstractResultSet
             && (this.rowsIterator.hasNext() || (this.rowNumber == 0 && this.currentRow != null));
     }
 
+    boolean isQuery() {
+        return this.driverResultSet != null && this.driverResultSet.getColumnDefinitions().size() > 0;
+    }
+
     @Override
     public boolean isAfterLast() throws SQLException {
         checkNotClosed();

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraStatement.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraStatement.java
@@ -408,7 +408,7 @@ public class CassandraStatement extends AbstractStatement
         doExecute(query);
         // Return true if the first result is a non-null ResultSet object; false if the first result is an update count
         // or there is no result.
-        return this.currentResultSet != null && ((CassandraResultSet) this.currentResultSet).hasMoreRows();
+        return this.currentResultSet != null && ((CassandraResultSet) this.currentResultSet).isQuery();
     }
 
     @Override

--- a/src/test/java/com/ing/data/cassandra/jdbc/PreparedStatementsUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/PreparedStatementsUnitTest.java
@@ -92,11 +92,21 @@ class PreparedStatementsUnitTest extends UsingCassandraContainerTest {
     }
 
     @Test
+    void givenPreparedStatement_whenReturnsNoRows_returnTrueFromExecute() throws SQLException {
+        final String cql = "SELECT keyname FROM cf_test_ps WHERE t1iValue = ? ALLOW FILTERING";
+        final CassandraPreparedStatement prepStatement = sqlConnection.prepareStatement(cql);
+        prepStatement.setInt(1, 99999);
+        boolean isResultSet = prepStatement.execute();
+        assertTrue(isResultSet);
+    }
+
+    @Test
     void givenPreparedStatement_whenGetResultSetMetaData_returnExpectedMetadataResultSet() throws SQLException {
         final String cql = "SELECT keyname AS resKeyname, t1iValue FROM cf_test_ps WHERE t1bValue = ?";
         final CassandraPreparedStatement prepStatement = sqlConnection.prepareStatement(cql);
         prepStatement.setBoolean(1, true);
-        prepStatement.execute();
+        boolean isResultSet = prepStatement.execute();
+        assertTrue(isResultSet);
         final ResultSetMetaData rsMetaData = prepStatement.getMetaData();
         assertNotNull(rsMetaData);
         assertEquals(2, rsMetaData.getColumnCount());


### PR DESCRIPTION
Same check I use here https://github.com/DataGrip/cassandra-jdbc-driver/blob/35c7b593aaa6ffbfc355765400be525a56157e37/driver/src/main/java/com/dbschema/CassandraResultSet.java#L68