### PR TITLE
Support consistency level statements

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraConnection.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraConnection.java
@@ -130,7 +130,7 @@ public class CassandraConnection extends AbstractConnection implements Connectio
     @SuppressWarnings("SortedCollectionWithNonComparableKeys")
     private final Set<Statement> statements = new ConcurrentSkipListSet<>();
     private final ConcurrentMap<String, CassandraPreparedStatement> preparedStatements = new ConcurrentHashMap<>();
-    private final ConsistencyLevel defaultConsistencyLevel;
+    private ConsistencyLevel consistencyLevel;
     private int defaultFetchSize = FALLBACK_FETCH_SIZE;
     private String currentKeyspace;
     private final boolean debugMode;
@@ -157,7 +157,7 @@ public class CassandraConnection extends AbstractConnection implements Connectio
         this.optionSet = lookupOptionSet(sessionProperties.getProperty(TAG_COMPLIANCE_MODE));
         this.username = sessionProperties.getProperty(TAG_USER,
             defaultConfigProfile.getString(DefaultDriverOption.AUTH_PROVIDER_USER_NAME, StringUtils.EMPTY));
-        this.defaultConsistencyLevel = DefaultConsistencyLevel.valueOf(
+        this.consistencyLevel = DefaultConsistencyLevel.valueOf(
             sessionProperties.getProperty(TAG_CONSISTENCY_LEVEL,
                 defaultConfigProfile.getString(DefaultDriverOption.REQUEST_CONSISTENCY,
                     ConsistencyLevel.LOCAL_ONE.name())));
@@ -219,7 +219,7 @@ public class CassandraConnection extends AbstractConnection implements Connectio
         this.currentKeyspace = currentKeyspace;
         this.cSession = cSession;
         this.metadata = cSession.getMetadata();
-        this.defaultConsistencyLevel = defaultConsistencyLevel;
+        this.consistencyLevel = defaultConsistencyLevel;
         this.debugMode = debugMode;
         final List<TypeCodec<?>> codecs = new ArrayList<>();
         codecs.add(new TimestampToLongCodec());
@@ -379,8 +379,8 @@ public class CassandraConnection extends AbstractConnection implements Connectio
      *
      * @return The default consistency level applied to this connection.
      */
-    public ConsistencyLevel getDefaultConsistencyLevel() {
-        return this.defaultConsistencyLevel;
+    public ConsistencyLevel getConsistencyLevel() {
+        return this.consistencyLevel;
     }
 
     /**
@@ -404,6 +404,10 @@ public class CassandraConnection extends AbstractConnection implements Connectio
         // The rationale is there are no holdability to set in this implementation, so we are "silently ignoring" the
         // request, but it still throws an exception when called on closed connection.
         checkNotClosed();
+    }
+
+    public void setConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        this.consistencyLevel = consistencyLevel;
     }
 
     @Override

--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraPreparedStatement.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraPreparedStatement.java
@@ -215,7 +215,7 @@ public class CassandraPreparedStatement extends CassandraStatement
             }
             this.boundStatement = this.boundStatement
                 .setPageSize(this.getFetchSize()) // Set paging to avoid timeout and node harm.
-                .setConsistencyLevel(this.connection.getDefaultConsistencyLevel());
+                .setConsistencyLevel(this.connection.getConsistencyLevel());
             for (int i = 0; i < getBoundStatementVariableDefinitions().size(); i++) {
                 // Set parameters to null if unset.
                 if (!this.boundStatement.isSet(i)) {
@@ -271,7 +271,7 @@ public class CassandraPreparedStatement extends CassandraStatement
                     LOG.trace("CQL: {}", this.cql);
                 }
                 final BoundStatement boundStatement = statement.setConsistencyLevel(
-                    this.connection.getDefaultConsistencyLevel());
+                    this.connection.getConsistencyLevel());
                 final CompletionStage<AsyncResultSet> resultSetFuture = getCqlSession().executeAsync(boundStatement);
                 futures.add(resultSetFuture);
             }

--- a/src/main/java/com/ing/data/cassandra/jdbc/ListResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/ListResultSet.java
@@ -189,7 +189,7 @@ public class ListResultSet extends AbstractResultSet implements ResultSet {
             throw new SQLException("Use of columnLabel requires setColumnNames to be called first.");
         }
         for (int i = 0; i < columns.length; i++) {
-            if (columnLabel.equals(columns[i])) {
+            if (columnLabel.equals(columns[i].name)) {
                 index = i;
                 break;
             }
@@ -302,7 +302,7 @@ public class ListResultSet extends AbstractResultSet implements ResultSet {
     @Override
     public int findColumn(String columnLabel) throws SQLException {
         for (int i = 0; i < columns.length; i++) {
-            if (columns[i].equals(columnLabel)) {
+            if (columns[i].name.equals(columnLabel)) {
                 return i + 1;
             }
         }

--- a/src/main/java/com/ing/data/cassandra/jdbc/ListResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/ListResultSet.java
@@ -1,0 +1,601 @@
+/*
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.ing.data.cassandra.jdbc;
+
+import com.datastax.oss.driver.api.core.type.DataType;
+
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Blob;
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import static com.ing.data.cassandra.jdbc.utils.ErrorConstants.NOT_SUPPORTED;
+
+public class ListResultSet extends AbstractResultSet implements ResultSet {
+    private final List<Object[]> data;
+    private final ColumnMetaData[] columns;
+    private int currentRow = -1;
+    private boolean isClosed = false;
+
+    public ListResultSet(List<Object[]> data, ColumnMetaData[] columns) {
+        this.data = data;
+        this.columns = columns;
+    }
+
+    public ListResultSet(Object value, ColumnMetaData columnName) {
+        this.data = new ArrayList<>();
+        this.data.add(new Object[]{value});
+        this.columns = new ColumnMetaData[]{columnName};
+    }
+
+    @Override
+    public boolean next() {
+        if (data == null) {
+            return false;
+        }
+        if (currentRow < data.size() - 1) {
+            currentRow++;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void close() throws SQLException {
+        checkClosed();
+        this.isClosed = true;
+    }
+
+    private void checkClosed() throws SQLException {
+        if (isClosed) {
+            throw new SQLException("Result set already closed");
+        }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    @Override
+    DataType getCqlDataType(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    DataType getCqlDataType(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean wasNull() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getString(int columnIndex) throws SQLException {
+        if (currentRow >= data.size()) {
+            throw new SQLException("ResultSet exhausted, request currentRow = " + currentRow);
+        }
+        int adjustedColumnIndex = columnIndex - 1;
+        if (adjustedColumnIndex >= data.get(currentRow).length) {
+            throw new SQLException("Column index does not exist: " + columnIndex);
+        }
+        final Object val = data.get(currentRow)[adjustedColumnIndex];
+        return val != null ? val.toString() : null;
+    }
+
+    @Override
+    public boolean getBoolean(int columnIndex) throws SQLException {
+        checkClosed();
+        return Boolean.parseBoolean(getString(columnIndex));
+    }
+
+    @Override
+    public byte getByte(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public short getShort(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int getInt(int columnIndex) throws SQLException {
+        checkClosed();
+        return Integer.parseInt(getString(columnIndex));
+    }
+
+    @Override
+    public long getLong(int columnIndex) throws SQLException {
+        checkClosed();
+        return Long.parseLong(getString(columnIndex));
+    }
+
+    @Override
+    public float getFloat(int columnIndex) throws SQLException {
+        checkClosed();
+        return Float.parseFloat(getString(columnIndex));
+    }
+
+    @Override
+    public double getDouble(int columnIndex) throws SQLException {
+        checkClosed();
+        return Double.parseDouble(getString(columnIndex));
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public byte[] getBytes(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Date getDate(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Time getTime(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Timestamp getTimestamp(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public InputStream getBinaryStream(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getString(String columnLabel) throws SQLException {
+        checkClosed();
+        int index = -1;
+        if (columns == null) {
+            throw new SQLException("Use of columnLabel requires setColumnNames to be called first.");
+        }
+        for (int i = 0; i < columns.length; i++) {
+            if (columnLabel.equals(columns[i])) {
+                index = i;
+                break;
+            }
+        }
+        if (index == -1) {
+            throw new SQLException("Column " + columnLabel + " doesn't exist in this ResultSet");
+        }
+        return getString(index + 1);
+    }
+
+    @Override
+    public boolean getBoolean(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public byte getByte(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public short getShort(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int getInt(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public long getLong(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public float getFloat(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public double getDouble(String columnLabel) throws SQLException {
+        checkClosed();
+        return Double.parseDouble(getString(columnLabel));
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public byte[] getBytes(String columnLabel) throws SQLException {
+        return getString(columnLabel).getBytes();
+    }
+
+    @Override
+    public Date getDate(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Time getTime(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public InputStream getBinaryStream(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        checkClosed();
+        return new ListResultSetMetaData(columns);
+    }
+
+    @Override
+    public Object getObject(int columnIndex) throws SQLException {
+        if (currentRow >= data.size()) {
+            throw new SQLException("ResultSet exhausted, request currentRow = " + currentRow);
+        }
+        int adjustedColumnIndex = columnIndex - 1;
+        if (adjustedColumnIndex >= data.get(currentRow).length) {
+            throw new SQLException("Column index does not exist: " + columnIndex);
+        }
+        return data.get(currentRow)[adjustedColumnIndex];
+    }
+
+    @Override
+    public Object getObject(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int findColumn(String columnLabel) throws SQLException {
+        for (int i = 0; i < columns.length; i++) {
+            if (columns[i].equals(columnLabel)) {
+                return i + 1;
+            }
+        }
+        throw new SQLException("No such column " + columnLabel);
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean isBeforeFirst() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean isAfterLast() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean isFirst() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean isLast() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void beforeFirst() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void afterLast() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int getRow() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public int getFetchDirection() {
+        return ResultSet.FETCH_FORWARD;
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int getType() {
+        return ResultSet.TYPE_FORWARD_ONLY;
+    }
+
+    @Override
+    public int getConcurrency() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public Statement getStatement() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Blob getBlob(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Blob getBlob(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Date getDate(int columnIndex, Calendar cal) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Date getDate(String columnLabel, Calendar cal) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Time getTime(int columnIndex, Calendar cal) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Time getTime(String columnLabel, Calendar cal) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public URL getURL(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public URL getURL(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public RowId getRowId(int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public RowId getRowId(String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+    }
+
+    public static class ListResultSetMetaData implements ResultSetMetaData {
+        private final ColumnMetaData[] columnMetaData;
+
+        ListResultSetMetaData(ColumnMetaData[] columnMetaData) {
+            this.columnMetaData = columnMetaData;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public int getColumnCount() {
+            return this.columnMetaData.length;
+        }
+
+        @Override
+        public boolean isAutoIncrement(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public boolean isCaseSensitive(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public boolean isSearchable(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public boolean isCurrency(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public int isNullable(int column) {
+            return ResultSetMetaData.columnNullable;
+        }
+
+        @Override
+        public boolean isSigned(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public int getColumnDisplaySize(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public String getColumnLabel(int column) {
+            return columnMetaData[column - 1].name;
+        }
+
+        @Override
+        public String getColumnName(int column) {
+            return columnMetaData[column - 1].name;
+        }
+
+        @Override
+        public String getSchemaName(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public int getPrecision(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public int getScale(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public String getTableName(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public String getCatalogName(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public int getColumnType(int column) {
+            return columnMetaData[column - 1].getJavaType();
+        }
+
+        @Override
+        public String getColumnTypeName(int column) {
+            return columnMetaData[column - 1].typeName;
+        }
+
+        @Override
+        public boolean isReadOnly(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public boolean isWritable(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public boolean isDefinitelyWritable(int column) throws SQLException {
+            throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        }
+
+        @Override
+        public String getColumnClassName(int column) {
+            return columnMetaData[column - 1].getClassName();
+        }
+    }
+
+    public static class ColumnMetaData {
+        private final String name;
+        private final String typeName;
+        private final int type;
+        private final String className;
+
+        ColumnMetaData(String name, String typeName, int type, String className) {
+            this.name = name;
+            this.typeName = typeName;
+            this.type = type;
+            this.className = className;
+        }
+
+        int getJavaType() {
+            return type;
+        }
+
+        String getClassName() {
+            return className;
+        }
+    }
+}

--- a/src/main/java/com/ing/data/cassandra/jdbc/StatementExecutor.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/StatementExecutor.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.ing.data.cassandra.jdbc;
+
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
+public interface StatementExecutor {
+    List<StatementExecutor> EXECUTORS = Arrays.asList(SetConsistencyLevelExecutor.INSTANCE, GetConsistencyLevelExecutor.INSTANCE);
+
+
+    ExecutionResult execute(final CassandraConnection connection, final String cql) throws SQLException;
+
+    class ExecutionResult {
+        final ResultSet resultSet;
+
+        public ExecutionResult(ResultSet resultSet) {
+            this.resultSet = resultSet;
+        }
+    }
+
+    class SetConsistencyLevelExecutor implements StatementExecutor {
+        public static final SetConsistencyLevelExecutor INSTANCE = new SetConsistencyLevelExecutor();
+        private static final Pattern PATTERN = Pattern.compile("CONSISTENCY (\\w+)", CASE_INSENSITIVE);
+
+        @Override
+        public ExecutionResult execute(final CassandraConnection connection, final String cql) throws SQLException {
+            Matcher matcher = PATTERN.matcher(cql.trim());
+            if (!matcher.matches()) {
+                return null;
+            }
+            String level = matcher.group(1);
+            try {
+                connection.setConsistencyLevel(DefaultConsistencyLevel.valueOf(level.toUpperCase(Locale.ENGLISH)));
+            } catch (IllegalArgumentException e) {
+                throw new SQLException(e);
+            }
+            return new ExecutionResult(null);
+        }
+    }
+
+    class GetConsistencyLevelExecutor implements StatementExecutor {
+        public static final GetConsistencyLevelExecutor INSTANCE = new GetConsistencyLevelExecutor();
+        private static final Pattern PATTERN = Pattern.compile("CONSISTENCY", CASE_INSENSITIVE);
+
+        @Override
+        public ExecutionResult execute(final CassandraConnection connection, final String cql) throws SQLException {
+            Matcher matcher = PATTERN.matcher(cql.trim());
+            return matcher.matches()
+                ? new ExecutionResult(new ListResultSet(connection.getConsistencyLevel().name(),
+                    new ListResultSet.ColumnMetaData("consistency_level", "TEXT", Types.VARCHAR, "java.lang.String")))
+                : null;
+        }
+    }
+}

--- a/src/test/java/com/ing/data/cassandra/jdbc/ConnectionUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/ConnectionUnitTest.java
@@ -89,8 +89,8 @@ class ConnectionUnitTest extends UsingCassandraContainerTest {
         initConnection(KEYSPACE, "configfile=wrong_application.conf", "consistency=LOCAL_QUORUM",
             "localdatacenter=datacenter1");
         assertNotNull(sqlConnection);
-        assertNotNull(sqlConnection.getDefaultConsistencyLevel());
-        final ConsistencyLevel consistencyLevel = sqlConnection.getDefaultConsistencyLevel();
+        assertNotNull(sqlConnection.getConsistencyLevel());
+        final ConsistencyLevel consistencyLevel = sqlConnection.getConsistencyLevel();
         assertNotNull(consistencyLevel);
         assertEquals(ConsistencyLevel.LOCAL_QUORUM, consistencyLevel);
         sqlConnection.close();
@@ -145,8 +145,8 @@ class ConnectionUnitTest extends UsingCassandraContainerTest {
         assertNotNull(sqlConnection.getSession().getContext());
         assertNotNull(sqlConnection.getSession().getContext().getConfig());
         assertNotNull(sqlConnection.getSession().getContext().getConfig().getDefaultProfile());
-        assertNotNull(sqlConnection.getDefaultConsistencyLevel());
-        final ConsistencyLevel consistencyLevel = sqlConnection.getDefaultConsistencyLevel();
+        assertNotNull(sqlConnection.getConsistencyLevel());
+        final ConsistencyLevel consistencyLevel = sqlConnection.getConsistencyLevel();
         assertNotNull(consistencyLevel);
         assertEquals(ConsistencyLevel.TWO, consistencyLevel);
 

--- a/src/test/java/com/ing/data/cassandra/jdbc/ConsistencyLevelStatementsTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/ConsistencyLevelStatementsTest.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.ing.data.cassandra.jdbc;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Statement;
+
+import static com.ing.data.cassandra.jdbc.utils.ConsistencyLevelUtils.assertConsistencyLevel;
+import static com.ing.data.cassandra.jdbc.utils.ConsistencyLevelUtils.assertConsistencyLevelViaExecute;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ConsistencyLevelStatementsTest extends UsingCassandraContainerTest {
+    private static final String KEYSPACE = "test_keyspace";
+
+    @BeforeAll
+    static void finalizeSetUpTests() throws Exception {
+        initConnection(KEYSPACE, "localdatacenter=datacenter1");
+    }
+
+    @Test
+    void testSetConsistencyLevel() throws Exception {
+        assertNotNull(sqlConnection);
+        Statement statement = sqlConnection.createStatement();
+        boolean isQuery = statement.execute("CONSISTENCY EACH_QUORUM");
+        assertFalse(isQuery);
+        assertConsistencyLevel(sqlConnection, "EACH_QUORUM");
+    }
+
+    @Test
+    void testSetConsistencyLevelViaExecute() throws Exception {
+        assertNotNull(sqlConnection);
+        sqlConnection.createStatement().execute("CONSISTENCY LOCAL_SERIAL");
+        assertConsistencyLevelViaExecute(sqlConnection, "LOCAL_SERIAL");
+    }
+}

--- a/src/test/java/com/ing/data/cassandra/jdbc/DefaultConsistencyLevelTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/DefaultConsistencyLevelTest.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.ing.data.cassandra.jdbc;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.ing.data.cassandra.jdbc.utils.ConsistencyLevelUtils.assertConsistencyLevel;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DefaultConsistencyLevelTest extends UsingCassandraContainerTest {
+    private static final String KEYSPACE = "test_keyspace";
+
+    @BeforeAll
+    static void finalizeSetUpTests() throws Exception {
+        initConnection(KEYSPACE, "localdatacenter=datacenter1", "consistency=SERIAL");
+    }
+
+    @Test
+    void testDefaultConsistencyLevel() throws Exception {
+        assertNotNull(sqlConnection);
+        assertConsistencyLevel(sqlConnection, "SERIAL");
+    }
+}

--- a/src/test/java/com/ing/data/cassandra/jdbc/utils/ConsistencyLevelUtils.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/utils/ConsistencyLevelUtils.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.ing.data.cassandra.jdbc.utils;
+
+import com.ing.data.cassandra.jdbc.CassandraConnection;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConsistencyLevelUtils {
+    public static void assertConsistencyLevel(CassandraConnection sqlConnection, String level) throws SQLException {
+        ResultSet resultSet = sqlConnection.createStatement().executeQuery("CONSISTENCY");
+        assertEquals(1, resultSet.findColumn("consistency_level"));
+        assertTrue(resultSet.next());
+        assertEquals(level, resultSet.getString(1));
+    }
+
+    public static void assertConsistencyLevelViaExecute(CassandraConnection sqlConnection, String level) throws SQLException {
+        Statement statement = sqlConnection.createStatement();
+        boolean isQuery = statement.execute("CONSISTENCY");
+        assertTrue(isQuery);
+        ResultSet resultSet = statement.getResultSet();
+        assertEquals(1, resultSet.findColumn("consistency_level"));
+        assertTrue(resultSet.next());
+        assertEquals(level, resultSet.getString(1));
+    }
+}


### PR DESCRIPTION
This MR supports CQL shell consistency statements https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/cqlshConsistency.html

`CONSISTENCY [level]` and `CONSISTENCY`

It's convenient to have an option to change consistency level from cql instead of changing jdbc parameters and opening new connection

Implementation of ListResultSet is basic