### PR TITLE
Fix timestamp scale

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/types/JdbcTimestamp.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/types/JdbcTimestamp.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatter;
  * represented as a string, such as 2015-05-03 13:30:54.234 (yyyy-MM-dd hh:mm:ss.SSS).</p>
  */
 public class JdbcTimestamp extends AbstractJdbcType<Timestamp> {
+    private static final int TIMESTAMP_SCALE = 3;
 
     /**
      * Gets a {@code JdbcTimestamp} instance.
@@ -41,7 +42,7 @@ public class JdbcTimestamp extends AbstractJdbcType<Timestamp> {
 
     @Override
     public int getScale(final Timestamp obj) {
-        return DEFAULT_SCALE;
+        return TIMESTAMP_SCALE;
     }
 
     @Override

--- a/src/main/java/com/ing/data/cassandra/jdbc/types/JdbcTimestamp.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/types/JdbcTimestamp.java
@@ -25,7 +25,7 @@ import java.time.format.DateTimeFormatter;
  * represented as a string, such as 2015-05-03 13:30:54.234 (yyyy-MM-dd hh:mm:ss.SSS).</p>
  */
 public class JdbcTimestamp extends AbstractJdbcType<Timestamp> {
-    private static final int TIMESTAMP_SCALE = 3;
+    private static final int TIMESTAMP_SCALE = 3; // typically, JDBC drivers return scale of a second for timestamps
 
     /**
      * Gets a {@code JdbcTimestamp} instance.

--- a/src/test/java/com/ing/data/cassandra/jdbc/MetadataResultSetsUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/MetadataResultSetsUnitTest.java
@@ -591,7 +591,7 @@ class MetadataResultSetsUnitTest extends UsingCassandraContainerTest {
             foundColumns.get(14));
         assertEquals("time;92;18;null;null;null;1;false;2;true;true;false;null;0;0;0;0;18",
             foundColumns.get(15));
-        assertEquals("timestamp;93;31;null;null;null;1;false;2;true;true;false;null;0;0;0;0;31",
+        assertEquals("timestamp;93;31;null;null;null;1;false;2;true;true;false;null;0;3;0;0;31",
             foundColumns.get(16));
         assertEquals("CUSTOM;1111;-1;';';null;1;true;2;true;true;false;null;0;0;0;0;-1",
             foundColumns.get(17));

--- a/src/test/java/com/ing/data/cassandra/jdbc/ResultSetUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/ResultSetUnitTest.java
@@ -110,6 +110,16 @@ class ResultSetUnitTest extends UsingCassandraContainerTest {
     }
 
     @Test
+    void givenTimestampColumn_whenFetchingMetadata_columnScaleShouldBeCorrect() throws Exception {
+        final String cql = "select (timestamp) null from system.local";
+        final Statement statement = sqlConnection.createStatement();
+        final ResultSet rs = statement.executeQuery(cql);
+        assertTrue(rs.next());
+        int scale = rs.getMetaData().getScale(1);
+        assertEquals(3, scale);
+    }
+
+    @Test
     void givenResultSetWithRows_whenGetClob_returnExpectedValue() throws Exception {
         final String cql = "SELECT col_blob FROM tbl_test_blobs WHERE keyname = 'key1'";
         final Statement statement = sqlConnection.createStatement();


### PR DESCRIPTION
It should be equal to 3 because it supports milliseconds
https://cassandra.apache.org/doc/stable/cassandra/cql/types.html#timestamps