### PR TITLE
Fix fetching varint values

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraResultSet.java
@@ -977,8 +977,9 @@ public class CassandraResultSet extends AbstractResultSet
                 case ASCII:
                 case TEXT:
                     return this.currentRow.getString(columnIndex - 1);
-                case INT:
                 case VARINT:
+                    return this.currentRow.getObject(columnIndex - 1);
+                case INT:
                     return this.currentRow.getInt(columnIndex - 1);
                 case SMALLINT:
                     return this.currentRow.getShort(columnIndex - 1);

--- a/src/test/java/com/ing/data/cassandra/jdbc/ResultSetUnitTest.java
+++ b/src/test/java/com/ing/data/cassandra/jdbc/ResultSetUnitTest.java
@@ -18,6 +18,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLSyntaxErrorException;
@@ -128,6 +129,17 @@ class ResultSetUnitTest extends UsingCassandraContainerTest {
         assertTrue(rs.next());
         final byte[] byteArray = IOUtils.toByteArray(rs.getAsciiStream("col_ascii"));
         assertArrayEquals("testValueAscii".getBytes(StandardCharsets.US_ASCII), byteArray);
+    }
+
+    @Test
+    void givenVarintValue_whenFetching_returnExpectedValue() throws Exception {
+        final String cql = "select (varint) 1 from system.local";
+        final Statement statement = sqlConnection.createStatement();
+        final ResultSet rs = statement.executeQuery(cql);
+        assertTrue(rs.next());
+        Object result = rs.getObject(1);
+        assertNotNull(result);
+        assertEquals(BigInteger.valueOf(1), result);
     }
 
     @Test


### PR DESCRIPTION
Before the fix it was throwing `IndexOutOfBoundsException`
```
java.lang.IndexOutOfBoundsException
	at java.base/java.nio.Buffer.checkIndex(Buffer.java:749)
	at java.base/java.nio.HeapByteBuffer.getInt(HeapByteBuffer.java:439)
	at com.ing.data.cassandra.jdbc.utils.ByteBufferUtil.toInt(ByteBufferUtil.java:113)
	at com.ing.data.cassandra.jdbc.codec.VarintToIntCodec.decode(VarintToIntCodec.java:65)
	at com.ing.data.cassandra.jdbc.codec.VarintToIntCodec.decode(VarintToIntCodec.java:31)
	at com.datastax.oss.driver.api.core.data.GettableByIndex.get(GettableByIndex.java:90)
	at com.datastax.oss.driver.api.core.data.GettableByIndex.getInt(GettableByIndex.java:270)
	at com.ing.data.cassandra.jdbc.CassandraResultSet.getObject(CassandraResultSet.java:986)
```