### PR TITLE
fix: return empty ResultSet instead of throwing for unsupported FK/ve…

### DIFF
--- a/src/main/java/com/ing/data/cassandra/jdbc/CassandraDatabaseMetaData.java
+++ b/src/main/java/com/ing/data/cassandra/jdbc/CassandraDatabaseMetaData.java
@@ -270,7 +270,7 @@ public class CassandraDatabaseMetaData implements DatabaseMetaData {
                                        final String foreignCatalog,
                                        final String foreignSchema,
                                        final String foreignTable) throws SQLException {
-        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        return CassandraResultSet.EMPTY_RESULT_SET;
     }
 
     @Override
@@ -350,7 +350,7 @@ public class CassandraDatabaseMetaData implements DatabaseMetaData {
     public ResultSet getExportedKeys(final String catalog,
                                      final String schema,
                                      final String table) throws SQLException {
-        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        return CassandraResultSet.EMPTY_RESULT_SET;
     }
 
     @Override
@@ -411,7 +411,7 @@ public class CassandraDatabaseMetaData implements DatabaseMetaData {
     public ResultSet getImportedKeys(final String catalog,
                                      final String schema,
                                      final String table) throws SQLException {
-        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        return CassandraResultSet.EMPTY_RESULT_SET;
     }
 
     @Override
@@ -802,7 +802,7 @@ public class CassandraDatabaseMetaData implements DatabaseMetaData {
     public ResultSet getSuperTables(final String catalog,
                                     final String schemaPattern,
                                     final String tableNamePattern) throws SQLException {
-        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        return CassandraResultSet.EMPTY_RESULT_SET;
     }
 
     /**
@@ -823,7 +823,7 @@ public class CassandraDatabaseMetaData implements DatabaseMetaData {
     public ResultSet getSuperTypes(final String catalog,
                                    final String schemaPattern,
                                    final String typeNamePattern) throws SQLException {
-        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        return CassandraResultSet.EMPTY_RESULT_SET;
     }
 
     @Override
@@ -992,7 +992,7 @@ public class CassandraDatabaseMetaData implements DatabaseMetaData {
     public ResultSet getVersionColumns(final String catalog,
                                        final String schema,
                                        final String table) throws SQLException {
-        throw new SQLFeatureNotSupportedException(NOT_SUPPORTED);
+        return CassandraResultSet.EMPTY_RESULT_SET;
     }
 
     @Override


### PR DESCRIPTION


fix: return empty ResultSet instead of throwing for unsupported FK/version methods

Methods getExportedKeys(), getImportedKeys(), getCrossReference(), getVersionColumns(), getSuperTables(), and getSuperTypes() previously threw SQLFeatureNotSupportedException. Per the JDBC spec these methods must return a valid ResultSet — throwing an exception violates the spec and breaks tools like Liquibase that call them during schema snapshot.

Since Cassandra has no foreign keys, version columns, or super tables, returning an empty ResultSet is the correct JDBC-compliant behavior.

Fixes Liquibase snapshot command failing with SQLFeatureNotSupportedException.